### PR TITLE
chore: update tool versions to node 24.14.1 + pnpm 10.33.0, pnpm/action-setup to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
       - uses: browser-actions/setup-chrome@v2
       - run: chrome --version
 
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
+      - uses: actions/checkout@v6
 
       - uses: marocchino/tool-versions-action@v2
         id: versions
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 24.14.0
-pnpm 10.32.1
+nodejs 24.14.1
+pnpm 10.33.0

--- a/package.json
+++ b/package.json
@@ -48,5 +48,5 @@
     "tailwindcss": "^4.2.1",
     "xml2js": "^0.6.2"
   },
-  "packageManager": "pnpm@10.32.1"
+  "packageManager": "pnpm@10.33.0"
 }


### PR DESCRIPTION
## Summary

- `.tool-versions`: `nodejs 24.14.0` → `24.14.1`, `pnpm 10.32.1` → `10.33.0` (latest releases)
- `package.json`: `packageManager` updated from `pnpm@10.32.1` → `pnpm@10.33.0` to match `.tool-versions`
- `.github/workflows/ci.yml`: `pnpm/action-setup@v5` → `pnpm/action-setup@v6`, and the SHA-pinned `actions/checkout` simplified to `actions/checkout@v6` consistent with other repos

## No changes needed for

- `engines.node` — already `24.x` which correctly matches Node 24.14.1
- `actions/setup-node@v6`, `actions/cache@v5`, `browser-actions/setup-chrome@v2` — already up to date