### PR TITLE
Switch to unified processor for markdown plugins

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig, envField, sharpImageService } from "astro/config";
+import { unified } from "@astrojs/markdown-remark";
 import remarkCodeTitles from "remark-code-titles";
 import rehypeLazyImage from "rehype-plugin-image-native-lazy-loading";
 import mdx from "@astrojs/mdx";
@@ -15,9 +16,10 @@ export default defineConfig({
     shikiConfig: {
       theme: "dracula",
     },
-    remarkPlugins: [remarkCodeTitles],
-    rehypePlugins: [rehypeLazyImage],
-    extendDefaultPlugins: true,
+    processor: unified({
+      remarkPlugins: [remarkCodeTitles],
+      rehypePlugins: [rehypeLazyImage],
+    }),
   },
   integrations: [
     mdx(),
@@ -27,6 +29,11 @@ export default defineConfig({
   ],
   vite: {
     plugins: [tailwindcss()],
+    server: {
+      fs: {
+        strict: false,
+      },
+    },
   },
   env: {
     schema: {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
+    "@astrojs/markdown-remark": "^7.2.0",
     "@astrojs/mdx": "^7.0.0",
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@astrojs/markdown-remark':
+        specifier: ^7.2.0
+        version: 7.2.0
       '@astrojs/mdx':
         specifier: ^7.0.0
         version: 7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0))


### PR DESCRIPTION
## Summary

- **Switch to `@astrojs/markdown-remark`'s `unified` processor** — replaces the deprecated `remarkPlugins`/`rehypePlugins`/`extendDefaultPlugins` config with a single `processor` option that combines both.
- **Add `vite.server.fs.strict: false`** — allows serving files outside the project root during development (needed by some remark/rehype plugin workflows).
- **Add `@astrojs/markdown-remark` as a dependency** in `package.json` and `pnpm-lock.yaml`.